### PR TITLE
Replace console theme with custom minimal design

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,20 +3,12 @@ description: "Exploring technology, AI, and possible futures"
 baseurl: "/blogxyz"
 url: "https://amoha-98.github.io"
 
-header_pages:
-  - index.md
-  - about.md
-  - blog.md
-  - projects.md
-  - contact.md
-
-style: dark
+style: light
 
 footer: 'Connect with me on <a href="https://twitter.com/nidarmmv2">Twitter</a>'
 
 # Build settings
 markdown: kramdown
-remote_theme: b2a3e8/jekyll-theme-console
 
 plugins:
   - jekyll-feed

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,10 @@
+- title: Automatic Detection of Diabetic Retinopathy on Edge Devices
+  description: Investigated and compared vision models for edge deployment.
+  url: /projects/#automatic-detection-of-diabetic-retinopathy-on-edge-devices-bsc-dissertation
+- title: Location-Based Image Matching API — Patina Systems
+  description: FastAPI service for geospatial image matching.
+  url: /projects/#location-based-image-matching-api--patina-systems
+- title: Creative Writing LLM Fine-Tuning — Pagerift
+  description: Fine-tuned Gemma 3 for creative story writing.
+  url: /projects/#creative-writing-llm-fine-tuning--pagerift
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,5 @@
+<footer class="site-footer">
+  <div class="container">
+    <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}</p>
+  </div>
+</footer>

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,5 +1,6 @@
-<link rel="stylesheet" href="{{ '/assets/custom.css' | relative_url }}">
-<link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400..700&display=swap" rel="stylesheet">
 <script>
   const storedTheme = localStorage.getItem('theme');
   if (storedTheme) document.documentElement.setAttribute('data-theme', storedTheme);

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,13 @@
+<header class="site-header">
+  <nav class="nav">
+    <a href="{{ '/' | relative_url }}" class="nav-logo">{{ site.title }}</a>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <ul id="nav-links" class="nav-links">
+      <li><a href="{{ '/' | relative_url }}" class="{% if page.url == '/' %}active{% endif %}">Home</a></li>
+      <li><a href="{{ '/blog/' | relative_url }}" class="{% if page.url == '/blog/' %}active{% endif %}">Blog</a></li>
+      <li><a href="{{ '/projects/' | relative_url }}" class="{% if page.url == '/projects/' %}active{% endif %}">Projects</a></li>
+      <li><a href="{{ '/about/' | relative_url }}" class="{% if page.url == '/about/' %}active{% endif %}">About</a></li>
+      <li><a href="{{ '/contact/' | relative_url }}" class="{% if page.url == '/contact/' %}active{% endif %}">Contact</a></li>
+    </ul>
+  </nav>
+</header>

--- a/_includes/theme-toggle.html
+++ b/_includes/theme-toggle.html
@@ -1,0 +1,16 @@
+<button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">
+  <svg class="icon icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+  </svg>
+  <svg class="icon icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="5"/>
+    <line x1="12" y1="1" x2="12" y2="3"/>
+    <line x1="12" y1="21" x2="12" y2="23"/>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+    <line x1="1" y1="12" x2="3" y2="12"/>
+    <line x1="21" y1="12" x2="23" y2="12"/>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+</button>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,41 @@
+---
+layout: minimal
+---
+
+<section class="hero">
+  <h1>{{ site.title }}</h1>
+  <p class="tagline">{{ site.description }}</p>
+  <div class="intro">
+    {{ content }}
+  </div>
+  <a href="{{ '/blog/' | relative_url }}" class="button">Read the blog</a>
+</section>
+
+<section>
+  <h2>Recent Posts</h2>
+  <div class="grid">
+    {% assign posts = site.posts | slice: 0,3 %}
+    {% for post in posts %}
+      <article class="card">
+        <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+        <p class="post-meta">{{ post.date | date: "%B %d, %Y" }}</p>
+        <p>{{ post.excerpt | strip_html | truncatewords: 30 }}</p>
+      </article>
+    {% endfor %}
+  </div>
+  <a href="{{ '/blog/' | relative_url }}" class="button">View all posts</a>
+</section>
+
+<section>
+  <h2>Featured Projects</h2>
+  <div class="grid">
+    {% for project in site.data.projects %}
+      <article class="card">
+        <h3>{{ project.title }}</h3>
+        <p>{{ project.description }}</p>
+        <a href="{{ project.url | relative_url }}">Read more</a>
+      </article>
+    {% endfor %}
+  </div>
+  <a href="{{ '/projects/' | relative_url }}" class="button">View all projects</a>
+</section>

--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+  {%- include head-custom.html -%}
+</head>
+<body>
+  {% include header.html %}
+  {% include theme-toggle.html %}
+  <main class="container">
+    {{ content }}
+  </main>
+  {% include footer.html %}
+  <script src="{{ '/assets/js/main.js' | relative_url }}" defer></script>
+</body>
+</html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,10 @@
+---
+layout: minimal
+---
+
+<article>
+  <header>
+    <h1>{{ page.title }}</h1>
+  </header>
+  {{ content }}
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,22 @@
+---
+layout: minimal
+---
+
+<div id="reading-progress"></div>
+
+<article>
+  <header>
+    <h1>{{ page.title }}</h1>
+    <p class="post-meta">{{ page.date | date: "%B %d, %Y" }}{% if page.categories %} • {{ page.categories | join: ", " }}{% endif %}</p>
+  </header>
+  {{ content }}
+</article>
+
+<nav class="post-nav">
+  {% if page.previous %}
+    <a href="{{ page.previous.url | relative_url }}">&larr; {{ page.previous.title }}</a>
+  {% endif %}
+  {% if page.next %}
+    <a href="{{ page.next.url | relative_url }}" style="float:right;">{{ page.next.title }} &rarr;</a>
+  {% endif %}
+</nav>

--- a/about.md
+++ b/about.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: /about
+title: About
 permalink: /about/
 ---
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,13 +1,30 @@
 (function() {
   const button = document.getElementById('theme-toggle');
-  if (!button) return;
-  const stored = localStorage.getItem('theme');
-  if (stored) {
-    document.documentElement.setAttribute('data-theme', stored);
+  if (button) {
+    button.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', current);
+      localStorage.setItem('theme', current);
+      button.classList.add('rotate');
+      setTimeout(() => button.classList.remove('rotate'), 300);
+    });
   }
-  button.addEventListener('click', () => {
-    const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
-    document.documentElement.setAttribute('data-theme', current);
-    localStorage.setItem('theme', current);
-  });
+
+  const navToggle = document.getElementById('nav-toggle');
+  const navLinks = document.getElementById('nav-links');
+  if (navToggle && navLinks) {
+    navToggle.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+    });
+  }
+
+  const progress = document.getElementById('reading-progress');
+  if (progress) {
+    window.addEventListener('scroll', () => {
+      const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+      const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      const width = (scrollTop / scrollHeight) * 100;
+      progress.style.width = width + '%';
+    });
+  }
 })();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,274 @@
+/* Base colors */
+:root {
+  --bg-color: #ffffff;
+  --text-color: #333333;
+  --accent-color: #007bff;
+  --card-bg: #ffffff;
+  --border-color: #e5e7eb;
+}
+
+[data-theme='dark'] {
+  --bg-color: #121212;
+  --text-color: #f5f5f5;
+  --accent-color: #2196f3;
+  --card-bg: #1e1e1e;
+  --border-color: #333333;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: 'Inter', system-ui, sans-serif;
+  line-height: 1.6;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+h1 {
+  font-weight: 700;
+  font-size: 2.6rem;
+  margin-bottom: 0.5rem;
+}
+h2 {
+  font-weight: 600;
+  font-size: 2rem;
+  margin-top: 2rem;
+}
+h3 {
+  font-weight: 600;
+  font-size: 1.5rem;
+  margin-top: 1.5rem;
+}
+p {
+  line-height: 1.7;
+  max-width: 65ch;
+}
+
+a {
+  color: var(--accent-color);
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-color);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0.5rem 1rem;
+}
+
+.nav-logo {
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--text-color);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--text-color);
+  position: relative;
+  padding-bottom: 0.25rem;
+  transition: color 0.3s ease;
+}
+
+.nav-links a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--accent-color);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.nav-links a:hover::after,
+.nav-links a.active::after {
+  transform: scaleX(1);
+}
+
+.nav-links a.active {
+  color: var(--accent-color);
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--text-color);
+}
+
+@media (max-width: 600px) {
+  .nav-links {
+    position: absolute;
+    top: 60px;
+    right: 1rem;
+    flex-direction: column;
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
+    padding: 1rem;
+    display: none;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+}
+
+.theme-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease;
+}
+
+.theme-toggle.rotate {
+  transform: rotate(180deg);
+}
+
+.theme-toggle .icon {
+  width: 20px;
+  height: 20px;
+}
+
+.theme-toggle .icon-sun {
+  display: none;
+}
+
+[data-theme='dark'] .theme-toggle .icon-sun {
+  display: block;
+}
+
+[data-theme='dark'] .theme-toggle .icon-moon {
+  display: none;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 1rem 2rem;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.hero .tagline {
+  color: var(--accent-color);
+  margin-bottom: 1rem;
+}
+
+.button {
+  display: inline-block;
+  background: var(--accent-color);
+  color: #fff;
+  padding: 0.6rem 1.2rem;
+  border-radius: 6px;
+  text-decoration: none;
+  margin-top: 1rem;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}
+
+.button:active {
+  transform: scale(0.97);
+}
+
+.card {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  background: var(--card-bg);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  border-color: var(--accent-color);
+  box-shadow: 0 8px 12px rgba(0,0,0,0.05);
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.post-meta {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  text-align: center;
+  padding: 2rem 1rem;
+  margin-top: 2rem;
+}
+
+/* social links */
+.social-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+}
+
+.social-links a {
+  font-size: 1.5rem;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+
+.social-links a:hover {
+  transform: scale(1.2);
+}
+
+/* reading progress */
+#reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 4px;
+  width: 0;
+  background: var(--accent-color);
+  z-index: 999;
+}

--- a/blog.md
+++ b/blog.md
@@ -1,16 +1,16 @@
 ---
 layout: page
-title: /blog
+title: Blog
 permalink: /blog/
 ---
 
-# Blog Posts
-
+<div class="posts">
 {% for post in site.posts %}
-  <article>
-    <h2>
-      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      <span style="float: right; font-size: 0.8em;">{{ post.date | date: "%B %d, %Y %H:%M" }}</span>
-    </h2>
+  <article class="card">
+    <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+    <p class="post-meta">{{ post.date | date: "%B %d, %Y" }}{% if post.categories %} — {{ post.categories | join: ", " }}{% endif %}</p>
+    <p>{{ post.excerpt | strip_html | truncatewords: 30 }}</p>
   </article>
 {% endfor %}
+</div>
+

--- a/contact.md
+++ b/contact.md
@@ -1,5 +1,5 @@
 ---
-title: /contact
+title: Contact
 layout: page
 permalink: /contact/
 ---
@@ -8,12 +8,11 @@ permalink: /contact/
 
 Feel free to reach out to me on social media!
 
-<a href="https://twitter.com/nidarmmv2" target="_blank">Twitter: @nidarmmv2</a>
-
-<a href="https://www.linkedin.com/in/ahmed-mohamed-ahmed-a5387a294" target="_blank">LinkedIn: Ahmed Mohamed Ahmed</a>
-
-<a href="https://huggingface.co/NidarMM" target="_blank">Hugging Face: NidarMM</a>
-
-<a href="https://github.com/AMOHA-98" target="_blank">GitHub: AMOHA-98</a>
+<ul class="social-links">
+<li><a href="https://twitter.com/nidarmmv2" target="_blank" aria-label="Twitter">🐦</a></li>
+<li><a href="https://www.linkedin.com/in/ahmed-mohamed-ahmed-a5387a294" target="_blank" aria-label="LinkedIn">💼</a></li>
+<li><a href="https://huggingface.co/NidarMM" target="_blank" aria-label="Hugging Face">🤗</a></li>
+<li><a href="https://github.com/AMOHA-98" target="_blank" aria-label="GitHub">🐙</a></li>
+</ul>
 
 

--- a/index.md
+++ b/index.md
@@ -1,31 +1,9 @@
 ---
-title: /home
+title: Home
 layout: home
 permalink: /
 ---
 
-# Welcome to xyz-zyx
-
 Hello! I'm Ahmed, a recent Computer Science graduate experienced in architecting and deploying end-to-end machine-learning systems. My domain focus spans data engineering, computer vision, and Large Language Models. I thrive in project-driven environments and enjoy translating research into production solutions.
 
-Currently, I'm contributing to research at Google DeepMind via the University of Exeter on "Scientific Paper Understanding with Multimodal LLMs and Knowledge Graphs" while previously a data scientist at Kelpi, a biomaterials company. 
-
-## Recent Posts
-
-{% for post in site.posts limit:3 %}
-
-  <article>
-    <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
-    <time datetime="{{ post.date | date: "%Y-%m-%d" }}">{{ post.date | date_to_long_string }}</time>
-    <p>{{ post.content | strip_html | truncatewords: 30 }}</p>
-  </article>
-{% endfor %}
-
-[View all posts]({{ site.baseurl }}/blog/)
-
-## Featured Projects
-
-- [Technical Projects & Case Studies]({{ site.baseurl }}/projects/)
-- [Professional Experience]({{ site.baseurl }}/about/#experience)
-
-[View all projects]({{ site.baseurl }}/projects/)
+Currently, I'm contributing to research at Google DeepMind via the University of Exeter on "Scientific Paper Understanding with Multimodal LLMs and Knowledge Graphs" while previously a data scientist at Kelpi, a biomaterials company.

--- a/projects.md
+++ b/projects.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: /projects
+title: Projects
 permalink: /projects/
 ---
 


### PR DESCRIPTION
## Summary
- adopt Inter variable font and refreshed light/dark palette with clearer typographic hierarchy
- add animated theme toggle, hover underlines, and button/card micro-interactions
- show icon-based social links and a scroll progress bar on posts for subtle feedback

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688e82870a38832bb620126d2f7ec1be